### PR TITLE
Add repo docs and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Julian Molina
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,78 @@
+# ApoloWMS Monorepo
+
+This repository is managed with [Nx](https://nx.dev) and contains multiple applications and shared libraries.
+
+## Project layout
+
+```
+apps/
+  backend/         NestJS REST/Socket API (Node.js)
+  frontend-web/    Next.js + Electron web client
+  frontend-mobile/ Expo React Native mobile client
+libs/
+  shared/          Shared utilities and types
+packages/          External packages (currently empty)
+```
+
+The `docker-compose.yml.example` file provides a development stack with MySQL, the backend API and the web frontend.
+
+## Running with Docker Compose
+
+1. Copy the example compose file:
+
+   ```bash
+   cp docker-compose.yml.example docker-compose.yml
+   ```
+2. Edit `docker-compose.yml` to set the desired database name and password.
+3. Start the services:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+This will build the backend and frontend images and start MySQL. The backend container exposes port `3000` and the web frontend runs on port `3001`.
+
+## Seeding the database
+
+After the containers are running, seed the database from inside the backend container:
+
+```bash
+docker-compose exec backend npx ts-node prisma/seed.ts
+```
+
+This script populates the MySQL database with initial demo data used by the applications.
+
+## Running apps locally
+
+You can also run the projects without Docker. Install dependencies at the repo root and within each app (requires Node 18+ and npm):
+
+```bash
+npm install
+cd apps/backend && npm install
+cd ../frontend-web && npm install
+cd ../frontend-mobile && npm install
+```
+
+### Backend
+
+```bash
+cd apps/backend
+npm run start:dev
+```
+
+### Web frontend
+
+```bash
+cd apps/frontend-web
+npm run dev
+```
+
+### Mobile app
+
+```bash
+cd apps/frontend-mobile
+npm run start
+```
+
+The mobile project uses Expo so you can open it with the Expo client on a device or emulator.
+


### PR DESCRIPTION
## Summary
- add project overview in README
- document docker-compose usage, seeding and local dev commands
- provide MIT license

## Testing
- `npm test` *(fails: Missing script)*
- `npx nx run-many --target=test` *(fails: EHOSTUNREACH to npm registry)*