### PR TITLE
Integrate realtime chat via SocketProvider

### DIFF
--- a/apps/frontend-web/src/components/ClientProviders.tsx
+++ b/apps/frontend-web/src/components/ClientProviders.tsx
@@ -6,6 +6,7 @@ import { store } from "../store";
 import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
 import { ThemeProvider as StyledThemeProvider } from "styled-components";
 import { AuthProvider } from "@/context/AuthContext";
+import { SocketProvider } from "@/context/socketContext";
 import Notification from "../components/Notification/Notification";
 import { ThemeProviderClient, useThemeContext } from "@/components/ThemeContext";
 import { ToastContainer } from "react-toastify";
@@ -19,9 +20,11 @@ export default function ClientProviders({ children }: ClientProvidersProps) {
   return (
     <Provider store={store}>
       <AuthProvider>
-        <ThemeProviderClient>
-          <InnerProviders>{children}</InnerProviders>
-        </ThemeProviderClient>
+        <SocketProvider>
+          <ThemeProviderClient>
+            <InnerProviders>{children}</InnerProviders>
+          </ThemeProviderClient>
+        </SocketProvider>
       </AuthProvider>
     </Provider>
   );

--- a/apps/frontend-web/src/context/socketContext.tsx
+++ b/apps/frontend-web/src/context/socketContext.tsx
@@ -3,6 +3,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { io, Socket } from 'socket.io-client';
 import { API_URL } from '../lib/config';
+import { useAuth } from './AuthContext';
 
 interface SocketContextValue {
   socket: Socket | null;
@@ -16,9 +17,12 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [socket, setSocket] = useState<Socket | null>(null);
+  const { user } = useAuth();
 
   useEffect(() => {
-    const socketIo = io(API_URL); // Asegúrate de que la URL coincide con tu backend
+    const socketIo = io(API_URL, {
+      query: { username: user?.username ?? '' },
+    });
     socketIo.on('connect', () => {
       console.log('[SocketProvider] Conectado con ID:', socketIo.id);
     });
@@ -30,7 +34,7 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
       socketIo.disconnect();
       console.log('[SocketProvider] Socket desconectado.');
     };
-  }, []);
+  }, [user]);
 
   return (
     <SocketContext.Provider value={{ socket }}>


### PR DESCRIPTION
## Summary
- refactor chat page to load users/messages dynamically
- connect chat to Socket.IO and emit chatMessage events
- expose SocketProvider in client providers
- include username when establishing socket connection

## Testing
- `npm test` (fails: jest not found)
- `npm test` in frontend (fails: missing script)
- `npx tsc -p apps/frontend-web/tsconfig.json` (fails to compile)