### PR TITLE
Dynamic dashboard KPIs

### DIFF
--- a/apps/backend/src/dashboard/dashboard.module.ts
+++ b/apps/backend/src/dashboard/dashboard.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { DashboardController } from './dashboard.controller';
 import { DashboardService } from './dashboard.service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
+  imports: [PrismaModule, NotificationsModule],
   controllers: [DashboardController],
   providers: [DashboardService],
 })

--- a/apps/backend/src/dashboard/dashboard.service.ts
+++ b/apps/backend/src/dashboard/dashboard.service.ts
@@ -1,28 +1,44 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { NotificationsService } from '../notifications/notifications.service';
 
 @Injectable()
 export class DashboardService {
-  getKPIs() {
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  async getKPIs() {
+    const totalItems = await this.prisma.item.count();
+    const stockSum = await this.prisma.item.aggregate({
+      _sum: { stock: true },
+    });
+    const totalOrders = await this.prisma.picking.count();
+
+    const pickings = await this.prisma.picking.findMany({
+      select: { createdAt: true, updatedAt: true },
+    });
+    let avgProcessing = 0;
+    if (pickings.length > 0) {
+      const totalMs = pickings.reduce((acc, p) => {
+        return acc + (p.updatedAt.getTime() - p.createdAt.getTime());
+      }, 0);
+      avgProcessing = totalMs / pickings.length;
+    }
+    const hours = Math.floor(avgProcessing / 3600000);
+    const minutes = Math.floor((avgProcessing % 3600000) / 60000);
+
     return {
-      stock: 150,
-      orders: 20,
-      incidents: 2,
-      averageProcessingTime: '1h 30m',
+      items: totalItems,
+      stock: stockSum._sum.stock ?? 0,
+      orders: totalOrders,
+      incidents: 0,
+      averageProcessingTime: `${hours}h ${minutes}m`,
     };
   }
 
   getNotifications() {
-    return [
-      {
-        id: 1,
-        message: 'Nuevo pedido recibido',
-        timestamp: new Date(),
-      },
-      {
-        id: 2,
-        message: 'Incidencia reportada en recepción',
-        timestamp: new Date(),
-      },
-    ];
+    return this.notificationsService.getPendingNotifications();
   }
 }


### PR DESCRIPTION
## Summary
- compute dashboard KPIs and notifications from Prisma tables
- expose Prisma and notifications modules to dashboard service
- fetch live dashboard data on the web app

## Testing
- `npm test` *(fails: jest not found)*