### PR TITLE
Add notifications badge and seed updates

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -14,7 +14,7 @@ async function main() {
   await prisma.user.createMany({ data: usersData, skipDuplicates: true });
 
   // Insertar datos de prueba para el módulo Picking
-  const pickingData = Array.from({ length: 20 }, (_, i) => ({
+  const pickingData = Array.from({ length: 5 }, (_, i) => ({
     orderNumber: `ORD-${(i + 1).toString().padStart(3, '0')}`,
     quantity: Math.floor(Math.random() * 20) + 1,
   }));
@@ -30,13 +30,12 @@ async function main() {
   });
 
   // Insertar datos de prueba para el módulo Packing
-  await prisma.packing.createMany({
-    data: [
-      { packageId: 'PKG-001', itemsCount: 5, status: 'Pending' },
-      { packageId: 'PKG-002', itemsCount: 3, status: 'Completed' },
-    ],
-    skipDuplicates: true,
-  });
+  const packingData = pickingData.map((p, i) => ({
+    packageId: `PKG-${(i + 1).toString().padStart(3, '0')}`,
+    itemsCount: p.quantity,
+    status: 'Pending',
+  }));
+  await prisma.packing.createMany({ data: packingData, skipDuplicates: true });
 
   // Insertar datos de prueba para el módulo Location
   await prisma.location.createMany({
@@ -67,15 +66,15 @@ async function main() {
   });
 
   // Insertar datos de prueba para el módulo Putaway
-  const putawayData = Array.from({ length: 20 }, (_, i) => ({
+  const putawayData = packingData.map((pkg, i) => ({
     receiptId: `RCPT-${(i + 1).toString().padStart(3, '0')}`,
     location: i % 2 === 0 ? 'LOC-001' : 'LOC-002',
-    quantity: Math.floor(Math.random() * 50) + 1,
+    quantity: pkg.itemsCount,
   }));
   await prisma.putaway.createMany({ data: putawayData, skipDuplicates: true });
 
   // Insertar datos de prueba para el módulo Item
-  const itemsData = Array.from({ length: 100 }, (_, i) => ({
+  const itemsData = Array.from({ length: 10 }, (_, i) => ({
     sku: `SKU-${(i + 1).toString().padStart(3, '0')}`,
     name: `Producto ${i + 1}`,
     description: `Descripción del producto ${i + 1}`,

--- a/apps/backend/src/modules/items/__tests__/items.service.spec.ts
+++ b/apps/backend/src/modules/items/__tests__/items.service.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ItemsService } from '../items.service';
+import { PrismaClient } from '@prisma/client';
+import { NotFoundException } from '@nestjs/common';
+
+describe('ItemsService', () => {
+  let service: ItemsService;
+  let prisma: { item: { findUnique: jest.Mock; findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    prisma = {
+      item: {
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+      },
+    } as any;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ItemsService,
+        { provide: PrismaClient, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get<ItemsService>(ItemsService);
+  });
+
+  it('throws NotFoundException when item does not exist', async () => {
+    prisma.item.findUnique.mockResolvedValue(null);
+    await expect(service.findOne(1)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('returns items array on findAll', async () => {
+    const items = [{ id: 1, sku: 'test' }];
+    prisma.item.findMany.mockResolvedValue(items);
+    await expect(service.findAll()).resolves.toEqual(items);
+  });
+});

--- a/apps/frontend-web/src/components/Header/DashboardHeader.tsx
+++ b/apps/frontend-web/src/components/Header/DashboardHeader.tsx
@@ -5,10 +5,13 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import MenuIcon from "@mui/icons-material/Menu";
 import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import NotificationsIcon from "@mui/icons-material/Notifications";
+import Badge from "@mui/material/Badge";
 import IconButton from "@mui/material/IconButton";
 import { useAuth } from "@/context/AuthContext";
 import EditProfileModal from "./EditProfileModal";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
+import { useNotifications } from "@/hooks/useNotifications";
 
 interface DashboardHeaderProps {
   toggleDrawer: () => void;
@@ -42,6 +45,11 @@ const RightSection = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
+`;
+
+const NotificationButton = styled.div`
+  cursor: pointer;
+  color: #fff;
 `;
 
 const UserPill = styled.div`
@@ -86,6 +94,7 @@ export default function DashboardHeader({
 }: DashboardHeaderProps) {
   const { user } = useAuth();
   const [openProfile, setOpenProfile] = useState(false);
+  const notifications = useNotifications();
 
   return (
     <>
@@ -97,6 +106,12 @@ export default function DashboardHeader({
         </LeftSection>
 
         <RightSection>
+          <NotificationButton>
+            <Badge badgeContent={notifications.length} color="error">
+              <NotificationsIcon />
+            </Badge>
+          </NotificationButton>
+
           <UserPill onClick={() => setOpenProfile(true)}>
             <AvatarImage
               src="/logos/default-avatar.png"

--- a/apps/frontend-web/src/components/Notification/Notification.tsx
+++ b/apps/frontend-web/src/components/Notification/Notification.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from 'styled-components';
+import { useNotifications } from '@/hooks/useNotifications';
 
 const NotificationContainer = styled.div`
   position: fixed;
@@ -39,38 +40,9 @@ interface NotificationType {
 }
 
 const Notification: React.FC = () => {
-  const [notifications, setNotifications] = useState<NotificationType[]>([]);
-  const [isMounted, setIsMounted] = useState(false);
+  const notifications = useNotifications();
 
-  // Este efecto se asegura de que el componente se renderice solo en cliente.
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // Ejemplo: se simula agregar una notificación de éxito a los 2 segundos.
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      const newNotif: NotificationType = {
-        message: "Operación exitosa",
-        type: "success",
-        timestamp: new Date().getTime(),
-      };
-      setNotifications(prev => [...prev, newNotif]);
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Cada segundo se remueven las notificaciones que tengan más de 5 segundos.
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setNotifications(prev =>
-        prev.filter(notif => new Date().getTime() - notif.timestamp < 5000)
-      );
-    }, 1000);
-    return () => clearInterval(interval);
-  }, []);
-
-  if (!isMounted) return null;
+  if (typeof window === 'undefined') return null;
 
   return ReactDOM.createPortal(
     <NotificationContainer>


### PR DESCRIPTION
## Summary
- show notifications from websocket using `useNotifications`
- badge with unread count in `DashboardHeader`
- adjust seed data to create linked picking/packing/putaway examples
- add unit test for `ItemsService`

## Testing
- `npm test` in `apps/backend` *(fails: jest not found)*
- `npm test` in `apps/frontend-web`